### PR TITLE
Cron job scaffolding

### DIFF
--- a/apps/fileworker/package.json
+++ b/apps/fileworker/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build",
+    "build": "tsx ./scripts/build.ts",
     "preview": "npm run build && wrangler dev",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
@@ -15,7 +15,8 @@
     "test:svelte": "vitest -c ./vitest.config.svelte.ts",
     "deploy": "npm run build && wrangler deploy",
     "db:migrations:generate": "drizzle-kit generate",
-    "db:migrations:apply": "wrangler d1 migrations apply DB",
+    "db:migrations:apply:local": "wrangler d1 migrations apply DB --local",
+    "db:migrations:apply:remote": "wrangler d1 migrations apply DB --remote",
     "cf-typegen": "wrangler types && mv worker-configuration.d.ts src/"
   },
   "devDependencies": {
@@ -28,6 +29,7 @@
     "@sveltejs/vite-plugin-svelte": "^4.0.4",
     "autoprefixer": "^10.4.20",
     "drizzle-kit": "^0.30.1",
+    "esbuild": "0.24.2",
     "eslint": "^9.7.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-svelte": "^2.36.0",
@@ -39,11 +41,13 @@
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
     "tailwindcss": "^3.4.9",
+    "tsx": "4.19.2",
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.0.0",
     "vite": "^5.4.10",
     "vitest": "^2.0.4",
-    "wrangler": "^3.99.0"
+    "wrangler": "^3.99.0",
+    "zx": "8.2.4"
   },
   "dependencies": {
     "@hono/zod-validator": "^0.4.2",

--- a/apps/fileworker/scripts/build.ts
+++ b/apps/fileworker/scripts/build.ts
@@ -1,0 +1,31 @@
+import 'zx/globals'
+
+import { fileURLToPath } from 'url'
+import * as esbuild from 'esbuild'
+
+const baseDir = path.resolve(path.basename(fileURLToPath(import.meta.url)), '..')
+
+// Build the main app with Vite (which uses the SvelteKit plugin)
+await $({
+	env: process.env,
+	stdio: 'inherit',
+})`vite build`.verbose()
+
+// Move the _worker.js file built by Vite so that
+// it can be imported by `src/lib/worker.ts`
+await fs.move(
+	`${baseDir}/.svelte-kit/cloudflare/_worker.js`,
+	`${baseDir}/.svelte-kit/cloudflare/_worker_base.js`,
+)
+
+// Bundle everything together so that our Svelte app and
+// the cron handler are exported by _worker.js
+await esbuild.build({
+	entryPoints: [`${baseDir}/src/lib/_worker.ts`],
+	outfile: `${baseDir}/.svelte-kit/cloudflare/_worker.js`,
+	logLevel: 'info',
+	target: 'es2022',
+	format: 'esm',
+	bundle: true,
+	treeShaking: true,
+})

--- a/apps/fileworker/src/lib/_worker.ts
+++ b/apps/fileworker/src/lib/_worker.ts
@@ -1,0 +1,13 @@
+// @ts-ignore This file won't exist until it's built
+import worker from '../../.svelte-kit/cloudflare/_worker_base'
+import { handleCron } from './cron'
+
+// The SvelteKit Vite plugin does not give us a way
+// to export other handlers, so we have to do it manually.
+// This file gets built by `scripts/build.ts` after the main
+// app gets built.
+
+export default {
+	...worker,
+	scheduled: handleCron,
+}

--- a/apps/fileworker/src/lib/cron.ts
+++ b/apps/fileworker/src/lib/cron.ts
@@ -1,0 +1,10 @@
+import { DBStore } from './db/store'
+
+import type { Env } from '../app'
+
+export async function handleCron(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
+	console.log('Cleaning DB store...')
+	const store = new DBStore(env.DB)
+	console.log(store)
+	// TODO
+}

--- a/apps/fileworker/wrangler.jsonc
+++ b/apps/fileworker/wrangler.jsonc
@@ -18,6 +18,11 @@
 		"head_sampling_rate": 1
 	},
 
+	"triggers": {
+		// Hourly Cron trigger to clean up expired files
+		"crons": ["38 * * * *"]
+	},
+
 	"r2_buckets": [
 		{
 			"binding": "R2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       drizzle-kit:
         specifier: ^0.30.1
         version: 0.30.1
+      esbuild:
+        specifier: 0.24.2
+        version: 0.24.2
       eslint:
         specifier: ^9.7.0
         version: 9.17.0(jiti@1.21.7)
@@ -183,6 +186,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.9
         version: 3.4.17(ts-node@10.9.2(@types/node@20.8.3)(typescript@5.5.4))
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
       typescript:
         specifier: ^5.0.0
         version: 5.5.4
@@ -198,6 +204,9 @@ importers:
       wrangler:
         specifier: ^3.99.0
         version: 3.99.0(@cloudflare/workers-types@4.20241230.0)
+      zx:
+        specifier: 8.2.4
+        version: 8.2.4
 
   apps/fileworker-api:
     dependencies:


### PR DESCRIPTION
Adds `scripts/build.ts` to build the main svelte app first, and then bundle our Cron `scheduled` handler with it using esbuild